### PR TITLE
fix(Dockerfile): Moved 'COPY . .' layer upwards so Slippy.AppImage is acessible; added installation of Slippi Gecko Codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y python3 python3-pip x11vnc xvfb libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev libgtk2.0-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libxext-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev libpng-dev qtbase5-private-dev libxxf86vm-dev x11proto-xinerama-dev xterm
 RUN apt clean -y && apt autoremove -y && apt autoclean -y
-COPY requirements.txt .
-RUN pip3 install -r requirements.txt
-RUN ./Slippy.AppImage --appimage-extract
 COPY . .
-RUN echo "exec python3 /app/example.py -e /app/squashfs-root/usr/bin --iso iso/smash.iso" > ~/.xinitrc && chmod +x ~/.xinitrc
-RUN mkdir -p /root/.config/SlippiOnline/Config
-RUN cp Dolphin.ini /root/.config/SlippiOnline/Config/Dolphin.ini
+RUN pip3 install -r requirements.txt \
+    && ./Slippy.AppImage --appimage-extract \
+    && curl -fsSL https://raw.githubusercontent.com/altf4/slippi-ssbm-asm/libmelee/Output/Netplay/GALE01r2.ini > ./squashfs-root/usr/bin/Sys/GameSettings/GALE01r2.ini \
+    && echo "exec python3 /app/example.py -e /app/squashfs-root/usr/bin --iso iso/smash.iso" > ~/.xinitrc && chmod +x ~/.xinitrc \
+    && mkdir -p /root/.config/SlippiOnline/Config \
+    && cp Dolphin.ini /root/.config/SlippiOnline/Config/Dolphin.ini
 EXPOSE 5900
 CMD ["x11vnc", "-create", "-forever"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y python3 python3-pip x11vnc xvfb libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev libgtk2.0-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libxext-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev libpng-dev qtbase5-private-dev libxxf86vm-dev x11proto-xinerama-dev xterm
 RUN apt clean -y && apt autoremove -y && apt autoclean -y
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt 
 COPY . .
-RUN pip3 install -r requirements.txt \
-    && ./Slippy.AppImage --appimage-extract \
+RUN ./Slippy.AppImage --appimage-extract \
     && curl -fsSL https://raw.githubusercontent.com/altf4/slippi-ssbm-asm/libmelee/Output/Netplay/GALE01r2.ini > ./squashfs-root/usr/bin/Sys/GameSettings/GALE01r2.ini \
-    && echo "exec python3 /app/example.py -e /app/squashfs-root/usr/bin --iso iso/smash.iso" > ~/.xinitrc && chmod +x ~/.xinitrc \
     && mkdir -p /root/.config/SlippiOnline/Config \
-    && cp Dolphin.ini /root/.config/SlippiOnline/Config/Dolphin.ini
+    && cp Dolphin.ini /root/.config/SlippiOnline/Config/Dolphin.ini \
+    && echo "exec python3 /app/example.py -e /app/squashfs-root/usr/bin --iso iso/smash.iso" > ~/.xinitrc && chmod +x ~/.xinitrc
 EXPOSE 5900
 CMD ["x11vnc", "-create", "-forever"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker build . -t slippi-melee
 
 #### Run it as 
 ```bash
-docker run -p 5900:5900 -v <your legit smash iso>:/app/smash.iso slippi-melee
+docker run -p 5900:5900 -v <your legit smash iso>:/app/iso/smash.iso slippi-melee
 ```
 
 #### See the game output


### PR DESCRIPTION
Few changes in the Dockerfile for the game to actually start (SlippyImage was being accessed before being copied; Added custom Slippi Gecko Codes into file).
Joining multiple commands into one layer might no be the best approach but it reduces the number of layers.
